### PR TITLE
Vérifie la présence de Bootstrap avant d'utiliser Collapse

### DIFF
--- a/js/header.js
+++ b/js/header.js
@@ -73,7 +73,14 @@ document.addEventListener("DOMContentLoaded", function () {
       window.scrollTo({ top: y, behavior: "smooth" });
       // Ferme le menu mobile si ouvert
       const c = document.getElementById("mainNavbar");
-      if (c?.classList.contains("show")) new bootstrap.Collapse(c).hide();
+      if (c?.classList.contains("show")) {
+        if (window.bootstrap && typeof window.bootstrap.Collapse === "function") {
+          new bootstrap.Collapse(c).hide();
+        } else {
+          c.classList.remove("show");
+          console.warn("Bootstrap non chargé : fermeture manuelle du menu.");
+        }
+      }
     });
     // Harmonise l'URL (facultatif)
     nlLink.setAttribute("href", "#newsletter");


### PR DESCRIPTION
## Summary
- Vérifie la présence de `window.bootstrap` avant d'instancier `bootstrap.Collapse` pour la navigation.
- Ajoute un repli manuel et un avertissement console quand Bootstrap est absent.

## Testing
- `npm test` *(échoue : package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_e_689ed2da6920832b9fffc252b25ef245