### PR TITLE
Simplify luxe templates layout

### DIFF
--- a/template-ui/bonnes_affaires_luxe.html
+++ b/template-ui/bonnes_affaires_luxe.html
@@ -17,13 +17,12 @@
   <link rel="stylesheet" href="./yume_luxe_nb.css">
   <style>
     body{color:#111}
-    .wrap{max-width:1140px;margin:auto;padding:64px 20px}
   </style>
 </head>
 <body>
 <script src="../js/header.js" defer></script>
 
-<main class="wrap">
+<main class="container py-5">
   <header class="text-center mb-4 reveal">
     <div class="jp-kicker mb-2"><span class="jp-rule"></span>Avantages partenaires</div>
     <h1 class="jp-title" style="font-size:28px;">Le coin des bonnes affaires</h1>

--- a/template-ui/dashboard_luxe.html
+++ b/template-ui/dashboard_luxe.html
@@ -17,13 +17,12 @@
   <link rel="stylesheet" href="./yume_luxe_nb.css">
   <style>
     body{color:#111}
-    .wrap{max-width:1140px;margin:auto;padding:64px 20px}
   </style>
 </head>
 <body>
 <script src="../js/header.js" defer></script>
 
-<main class="wrap">
+<main class="container py-5">
   <header class="text-center reveal">
     <div class="jp-kicker mb-2"><span class="jp-rule"></span>Mon espace</div>
     <h1 class="jp-title" style="font-size:28px;">Tableau de bord</h1>

--- a/template-ui/index_ui_luxe.html
+++ b/template-ui/index_ui_luxe.html
@@ -17,13 +17,12 @@
   <link rel="stylesheet" href="./yume_luxe_nb.css">
   <style>
     body{color:#111}
-    .wrap{max-width:1140px;margin:auto;padding:64px 20px}
   </style>
 </head>
 <body>
 <script src="../js/header.js" defer></script>
 
-<main class="wrap">
+<main class="container py-5">
   <header class="text-center mb-4 reveal">
     <div class="jp-kicker mb-2"><span class="jp-rule"></span>Design system</div>
     <h1 class="jp-title" style="font-size:28px;">Index des templates UI</h1>

--- a/template-ui/inscription_luxe.html
+++ b/template-ui/inscription_luxe.html
@@ -17,13 +17,12 @@
   <link rel="stylesheet" href="./yume_luxe_nb.css">
   <style>
     body{color:#111}
-    .wrap{max-width:1140px;margin:auto;padding:64px 20px}
   </style>
 </head>
 <body>
 <script src="../js/header.js" defer></script>
 
-<main class="wrap">
+<main class="container py-5">
   <header class="text-center mb-4 reveal">
     <div class="jp-kicker mb-2"><span class="jp-rule"></span>Créer un compte</div>
     <h1 class="jp-title" style="font-size:28px;">Rejoins YUME</h1>

--- a/template-ui/media_luxe.html
+++ b/template-ui/media_luxe.html
@@ -17,7 +17,6 @@
   <link rel="stylesheet" href="./yume_luxe_nb.css">
   <style>
     body{color:#111}
-    .wrap{max-width:1140px;margin:auto;padding:64px 20px}
   </style>
 </head>
 <body>
@@ -69,7 +68,7 @@
   <div class="lux-scroll">Faites défiler</div>
 </section>
 
-<main class="wrap">
+<main class="container py-5">
   <section id="episode-vedette" class="jp-card p-4 p-md-5 mb-5 reveal">
     <h2 class="jp-title fs-6 mb-3">Épisode en vedette</h2>
     <p class="muted mb-3">#5 — Récit d’une qualification inattendue</p>

--- a/template-ui/messagerie_luxe.html
+++ b/template-ui/messagerie_luxe.html
@@ -17,13 +17,12 @@
   <link rel="stylesheet" href="./yume_luxe_nb.css">
   <style>
     body{color:#111}
-    .wrap{max-width:1140px;margin:auto;padding:64px 20px}
   </style>
 </head>
 <body>
 <script src="../js/header.js" defer></script>
 
-<main class="wrap">
+<main class="container py-5">
   <header class="text-center mb-4 reveal">
     <div class="jp-kicker mb-2"><span class="jp-rule"></span>Messages</div>
     <h1 class="jp-title" style="font-size:28px;">Messagerie privée</h1>

--- a/template-ui/panier_luxe.html
+++ b/template-ui/panier_luxe.html
@@ -17,13 +17,12 @@
   <link rel="stylesheet" href="./yume_luxe_nb.css">
   <style>
     body{color:#111}
-    .wrap{max-width:1140px;margin:auto;padding:64px 20px}
   </style>
 </head>
 <body>
 <script src="../js/header.js" defer></script>
 
-<main class="wrap">
+<main class="container py-5">
   <header class="mb-4 reveal">
     <div class="jp-kicker mb-2 text-center"><span class="jp-rule"></span>Commande</div>
     <h1 class="jp-title text-center" style="font-size:28px;">Mon panier</h1>

--- a/template-ui/partenaires_luxe.html
+++ b/template-ui/partenaires_luxe.html
@@ -17,13 +17,12 @@
   <link rel="stylesheet" href="./yume_luxe_nb.css">
   <style>
     body{color:#111}
-    .wrap{max-width:1140px;margin:auto;padding:64px 20px}
   </style>
 </head>
 <body>
 <script src="../js/header.js" defer></script>
 
-<main class="wrap">
+<main class="container py-5">
   <header class="text-center mb-4 reveal">
     <div class="jp-kicker mb-2"><span class="jp-rule"></span>Écosystème</div>
     <h1 class="jp-title" style="font-size:28px;">Partenaires & Objets certifiés</h1>

--- a/template-ui/produit_luxe.html
+++ b/template-ui/produit_luxe.html
@@ -17,13 +17,12 @@
   <link rel="stylesheet" href="./yume_luxe_nb.css">
   <style>
     body{color:#111}
-    .wrap{max-width:1140px;margin:auto;padding:64px 20px}
   </style>
 </head>
 <body>
 <script src="../js/header.js" defer></script>
 
-<main class="wrap">
+<main class="container py-5">
   <section class="row g-4">
     <div class="col-md-7 reveal">
       <div class="jp-card overflow-hidden">

--- a/template-ui/recherche_luxe.html
+++ b/template-ui/recherche_luxe.html
@@ -17,13 +17,12 @@
   <link rel="stylesheet" href="./yume_luxe_nb.css">
   <style>
     body{color:#111}
-    .wrap{max-width:1140px;margin:auto;padding:64px 20px}
   </style>
 </head>
 <body>
 <script src="../js/header.js" defer></script>
 
-<main class="wrap">
+<main class="container py-5">
   <header class="mb-4 reveal">
     <div class="jp-kicker mb-2"><span class="jp-rule"></span>Explorer</div>
     <h1 class="jp-title" style="font-size:28px;">Résultats de recherche</h1>

--- a/template-ui/sportifs_luxe.html
+++ b/template-ui/sportifs_luxe.html
@@ -12,7 +12,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./yume_luxe_nb.css">
-  <style>body{color:#111} .wrap{max-width:1140px;margin:auto;padding:64px 20px}
+  <style>body{color:#111}
   .jp-title{font-family:"Playfair Display",ui-serif,Georgia,serif; text-transform:uppercase; letter-spacing:.22em;}
   .jp-kicker{font-size:10px; letter-spacing:.3em; text-transform:uppercase; color:#9a9a9a; display:inline-flex; align-items:center; gap:10px;}
   .jp-rule{width:28px; height:1px; background:rgba(0,0,0,.14); display:inline-block;}
@@ -23,7 +23,7 @@
   .muted{color:#666;} .reveal{opacity:0; transform:translateY(14px); transition:opacity .6s ease, transform .6s ease;} .reveal.in-view{opacity:1; transform:none;}
   .thumb-cover{width:100%; height:220px; object-fit:cover; border-top-left-radius:22px; border-top-right-radius:22px;}
   </style></head><body><script src="../js/header.js" defer></script>
-<main class="wrap">
+<main class="container py-5">
   <header class="text-center mb-4 reveal">
     <div class="jp-kicker mb-2"><span class="jp-rule"></span>Communauté</div>
     <h1 class="jp-title" style="font-size:28px;">Sportifs soutenus</h1>

--- a/template-ui/voeu_luxe.html
+++ b/template-ui/voeu_luxe.html
@@ -12,7 +12,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./yume_luxe_nb.css">
-  <style>body{color:#111} .wrap{max-width:1140px;margin:auto;padding:64px 20px}
+  <style>body{color:#111}
   .jp-title{font-family:"Playfair Display",ui-serif,Georgia,serif; text-transform:uppercase; letter-spacing:.22em;}
   .jp-kicker{font-size:10px; letter-spacing:.3em; text-transform:uppercase; color:#9a9a9a; display:inline-flex; align-items:center; gap:10px;}
   .jp-rule{width:28px; height:1px; background:rgba(0,0,0,.14); display:inline-block;}
@@ -23,7 +23,7 @@
   .muted{color:#666;} .reveal{opacity:0; transform:translateY(14px); transition:opacity .6s ease, transform .6s ease;} .reveal.in-view{opacity:1; transform:none;}
   .thumb-cover{width:100%; height:220px; object-fit:cover; border-top-left-radius:22px; border-top-right-radius:22px;}
   </style></head><body><script src="../js/header.js" defer></script>
-<main class="wrap">
+<main class="container py-5">
   <header class="text-center mb-4 reveal">
     <div class="jp-kicker mb-2"><span class="jp-rule"></span>Expérience</div>
     <h1 class="jp-title" style="font-size:28px;">Faites un vœu</h1>


### PR DESCRIPTION
## Summary
- Replace legacy `.wrap` wrapper with `<main class="container py-5">` in all luxe templates
- Drop `.wrap` style block and rely on Bootstrap spacing utilities

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ed446d3ac832baca7149440649316