### PR TITLE
Add lazy loading to audio elements

### DIFF
--- a/media.html
+++ b/media.html
@@ -184,7 +184,7 @@
       <a id="whatIsYumeLink" href="#intro-audio" class="player-link">Qu’est-ce que YUME&nbsp;?</a>
      </div>
  </div>
-    <audio id="intro-audio" controls class="w-100 rounded-4 border" style="border-color: rgba(0,0,0,.15);">
+    <audio id="intro-audio" controls preload="none" class="w-100 rounded-4 border" style="border-color: rgba(0,0,0,.15);">
     <source src="audio/YUME___La_Seconde_Main_Solidaire_qui_Rêve_de_Grandir.mp3" type="audio/mpeg" />
      Votre navigateur ne supporte pas l’audio HTML5.
     </audio>
@@ -202,7 +202,7 @@
   <div class="row align-items-center">
     <div class="col-md-6">
       <img src="img/episode5.png" alt="Épisode 5 - Delphine - Alliance Locale" class="img-fluid rounded">
-      <audio controls class="w-100 mt-3">
+      <audio controls preload="none" class="w-100 mt-3">
         <source src="audio/Episode 5_Delphine_Alliance locale_YUME.mp3" type="audio/mpeg">
         Ton navigateur ne supporte pas l'audio HTML5.
       </audio>
@@ -227,7 +227,7 @@
   <div class="row align-items-center">
     <div class="col-md-6">
       <img src="img/episode4.png" alt="Épisode 4 - Véronique - Life Cover" class="img-fluid rounded">
-      <audio controls class="w-100 mt-3">
+      <audio controls preload="none" class="w-100 mt-3">
         <source src="audio/Episode 4_Véronique_Life Cover_YUME.mp3" type="audio/mpeg">
         Ton navigateur ne supporte pas l'audio HTML5.
       </audio>
@@ -250,7 +250,7 @@
   <div class="row align-items-center">
     <div class="col-md-6">
       <img src="img/episode3.png" alt="Episode 3" class="img-fluid rounded">
-      <audio controls class="w-100 mt-3">
+      <audio controls preload="none" class="w-100 mt-3">
         <source src="audio/Episode 3_Ella Bassler_Incroyable Territoire_YUME.mp3" type="audio/mpeg">
         Ton navigateur ne supporte pas l'audio HTML5.
       </audio>
@@ -275,7 +275,7 @@
   <div class="row align-items-center">
     <div class="col-md-6">
       <img src="img/episode2.png" alt="Episode 2" class="img-fluid rounded">
-      <audio controls class="w-100 mt-3">
+      <audio controls preload="none" class="w-100 mt-3">
         <source src="audio/Episode 2_Ermanno Di Miceli_Ton rêve Ton combat_YUME.mp3" type="audio/mpeg">
         Ton navigateur ne supporte pas l'audio HTML5.
       </audio>
@@ -308,7 +308,7 @@
   <div class="row align-items-center">
     <div class="col-md-6">
       <img src="img/episode1.png" alt="Episode" class="img-fluid rounded">
-      <audio controls class="w-100 mt-3">
+      <audio controls preload="none" class="w-100 mt-3">
         <source src="audio/Episode 1_Yannick Matejicek_Ton rêve Ton combat_YUME.mp3" type="audio/mpeg">
         Ton navigateur ne supporte pas l'audio HTML5.
       </audio>

--- a/template-ui/media_luxe.html
+++ b/template-ui/media_luxe.html
@@ -72,7 +72,7 @@
   <section id="episode-vedette" class="jp-card p-4 p-md-5 mb-5 reveal">
     <h2 class="jp-title fs-6 mb-3">Épisode en vedette</h2>
     <p class="muted mb-3">#5 — Récit d’une qualification inattendue</p>
-    <audio id="intro-audio" controls class="w-100 rounded-4 border" style="border-color: rgba(0,0,0,.15);">
+    <audio id="intro-audio" controls preload="none" class="w-100 rounded-4 border" style="border-color: rgba(0,0,0,.15);">
       <source src="/media/yume-intro.mp3" type="audio/mpeg" />
     </audio>
   </section>


### PR DESCRIPTION
## Summary
- defer audio loading until playback by setting `preload="none"`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ed7545684832b97849b4455c54647