### PR TITLE
feat: link templates ui and load footer

### DIFF
--- a/template-ui/bonnes_affaires_luxe.html
+++ b/template-ui/bonnes_affaires_luxe.html
@@ -53,6 +53,7 @@
 </main>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" defer></script>
+<script src="./js/footer.js" defer></script>
 <script>
   // Reveal
   const io = new IntersectionObserver((es)=>es.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in-view'); io.unobserve(e.target); } }),{threshold:.15});

--- a/template-ui/dashboard_luxe.html
+++ b/template-ui/dashboard_luxe.html
@@ -55,6 +55,7 @@
 </main>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" defer></script>
+<script src="./js/footer.js" defer></script>
 <script>
   // Reveal
   const io = new IntersectionObserver((es)=>es.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in-view'); io.unobserve(e.target); } }),{threshold:.15});

--- a/template-ui/inscription_luxe.html
+++ b/template-ui/inscription_luxe.html
@@ -43,6 +43,7 @@
 </main>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" defer></script>
+<script src="./js/footer.js" defer></script>
 <script>
   // Reveal
   const io = new IntersectionObserver((es)=>es.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in-view'); io.unobserve(e.target); } }),{threshold:.15});

--- a/template-ui/js/footer.js
+++ b/template-ui/js/footer.js
@@ -20,6 +20,8 @@ document.addEventListener("DOMContentLoaded", function () {
   const footer = document.createElement("footer");
   footer.id = "yume-footer";
   footer.className = "yume-footer";
+  const isTemplatePage = window.location.pathname.endsWith("index_ui_luxe.html");
+  const templateLink = isTemplatePage ? "" : '<a class="jp-link" href="index_ui_luxe.html">Templates UI</a>';
   footer.innerHTML = `
     <div class="inner text-center">
       <div class="brand mb-2">YUME</div>
@@ -28,6 +30,7 @@ document.addEventListener("DOMContentLoaded", function () {
         <a class="jp-link" href="accueil.html">Accueil</a>
         <a class="jp-link" href="media.html">Média</a>
         <a class="jp-link" href="newsletter.html">Newsletter</a>
+        ${templateLink}
       </nav>
       <small>© ${year} YUME · Tous droits réservés</small>
     </div>

--- a/template-ui/media_luxe.html
+++ b/template-ui/media_luxe.html
@@ -114,6 +114,7 @@
 </script>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" defer></script>
+<script src="./js/footer.js" defer></script>
 <script>
   // Reveal
   const io = new IntersectionObserver((es)=>es.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in-view'); io.unobserve(e.target); } }),{threshold:.15});

--- a/template-ui/messagerie_luxe.html
+++ b/template-ui/messagerie_luxe.html
@@ -51,6 +51,7 @@
 </main>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" defer></script>
+<script src="./js/footer.js" defer></script>
 <script>
   // Reveal
   const io = new IntersectionObserver((es)=>es.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in-view'); io.unobserve(e.target); } }),{threshold:.15});

--- a/template-ui/panier_luxe.html
+++ b/template-ui/panier_luxe.html
@@ -68,6 +68,7 @@
 </main>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" defer></script>
+<script src="./js/footer.js" defer></script>
 <script>
   // Reveal
   const io = new IntersectionObserver((es)=>es.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in-view'); io.unobserve(e.target); } }),{threshold:.15});

--- a/template-ui/partenaires_luxe.html
+++ b/template-ui/partenaires_luxe.html
@@ -50,6 +50,7 @@
 </main>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" defer></script>
+<script src="./js/footer.js" defer></script>
 <script>
   // Reveal
   const io = new IntersectionObserver((es)=>es.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in-view'); io.unobserve(e.target); } }),{threshold:.15});

--- a/template-ui/produit_luxe.html
+++ b/template-ui/produit_luxe.html
@@ -65,6 +65,7 @@
 </main>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" defer></script>
+<script src="./js/footer.js" defer></script>
 <script>
   // Reveal
   const io = new IntersectionObserver((es)=>es.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in-view'); io.unobserve(e.target); } }),{threshold:.15});

--- a/template-ui/recherche_luxe.html
+++ b/template-ui/recherche_luxe.html
@@ -50,6 +50,7 @@
 </main>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" defer></script>
+<script src="./js/footer.js" defer></script>
 <script>
   // Reveal
   const io = new IntersectionObserver((es)=>es.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in-view'); io.unobserve(e.target); } }),{threshold:.15});

--- a/template-ui/sportifs_luxe.html
+++ b/template-ui/sportifs_luxe.html
@@ -77,7 +77,7 @@
 </main>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" defer></script>
-<script src="./footer.js" defer></script>
+<script src="./js/footer.js" defer></script>
 <script>
   const io = new IntersectionObserver((es)=>es.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in-view'); io.unobserve(e.target); } }),{threshold:.15});
   document.querySelectorAll('.reveal').forEach(el=>io.observe(el));

--- a/template-ui/voeu_luxe.html
+++ b/template-ui/voeu_luxe.html
@@ -62,7 +62,7 @@
 </main>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" defer></script>
-<script src="./footer.js" defer></script>
+<script src="./js/footer.js" defer></script>
 <script>
   const io = new IntersectionObserver((es)=>es.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in-view'); io.unobserve(e.target); } }),{threshold:.15});
   document.querySelectorAll('.reveal').forEach(el=>io.observe(el));


### PR DESCRIPTION
## Summary
- link Templates UI in footer unless on the templates index page
- load footer script on all template pages
- fix footer script path for sportifs and voeu templates

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689ee7daf624832b990d692cae090a44