### PR TITLE
Optimize media loading with lazy load and dimensions

### DIFF
--- a/accueil.html
+++ b/accueil.html
@@ -126,7 +126,7 @@
       <div class="row g-4">
         <div class="col-md-4">
           <div class="card jp-card hover-rise h-100">
-            <img src="img/sportif1.jpg" class="card-img-top" alt="Lisa – Lutte">
+            <img src="img/sportif1.jpg" class="card-img-top" alt="Lisa – Lutte" loading="lazy" width="1024" height="1024">
             <div class="card-body">
               <h5 class="fw-bold" style="letter-spacing:.04em;">Lisa, 14 ans — Lutte</h5>
               <p class="text-muted mb-3">Chaussures de compétition.</p>
@@ -136,7 +136,7 @@
         </div>
         <div class="col-md-4">
           <div class="card jp-card hover-rise h-100">
-            <img src="img/sportif2.jpg" class="card-img-top" alt="Yanis – Escrime">
+            <img src="img/sportif2.jpg" class="card-img-top" alt="Yanis – Escrime" loading="lazy" width="1024" height="1024">
             <div class="card-body">
               <h5 class="fw-bold" style="letter-spacing:.04em;">Yanis, 17 ans — Escrime</h5>
               <p class="text-muted mb-3">Nouveau fleuret. Cap sur Paris 2028.</p>
@@ -146,7 +146,7 @@
         </div>
         <div class="col-md-4">
           <div class="card jp-card hover-rise h-100">
-            <img src="img/spotfif3.jpg" class="card-img-top" alt="Maya – Trail">
+            <img src="img/spotfif3.jpg" class="card-img-top" alt="Maya – Trail" loading="lazy" width="1024" height="1536">
             <div class="card-body">
               <h5 class="fw-bold" style="letter-spacing:.04em;">Maya, 22 ans — Trail</h5>
               <p class="text-muted mb-3">Première course internationale.</p>
@@ -167,14 +167,14 @@
       <div class="overflow-auto">
         <div class="d-flex justify-content-start align-items-center gap-5"
              style="min-width:max-content;animation:defilement 30s linear infinite;">
-          <img src="img/partenaire1.png" alt="Partenaire 1" class="logo-partenaire">
-          <img src="img/partenaire2.png" alt="Partenaire 2" class="logo-partenaire">
-          <img src="img/partenaire3.png" alt="Partenaire 3" class="logo-partenaire">
-          <img src="img/partenaire4.png" alt="Partenaire 4" class="logo-partenaire">
-          <img src="img/partenaire5.png" alt="Partenaire 5" class="logo-partenaire">
-          <img src="img/partenaire6.png" alt="Partenaire 6" class="logo-partenaire">
-          <img src="img/partenaire1.png" alt="Partenaire 1" class="logo-partenaire">
-          <img src="img/partenaire2.png" alt="Partenaire 2" class="logo-partenaire">
+          <img src="img/partenaire1.png" alt="Partenaire 1" class="logo-partenaire" loading="lazy" width="1024" height="1024">
+          <img src="img/partenaire2.png" alt="Partenaire 2" class="logo-partenaire" loading="lazy" width="1024" height="1024">
+          <img src="img/partenaire3.png" alt="Partenaire 3" class="logo-partenaire" loading="lazy" width="1024" height="1024">
+          <img src="img/partenaire4.png" alt="Partenaire 4" class="logo-partenaire" loading="lazy" width="1024" height="1024">
+          <img src="img/partenaire5.png" alt="Partenaire 5" class="logo-partenaire" loading="lazy" width="1024" height="1024">
+          <img src="img/partenaire6.png" alt="Partenaire 6" class="logo-partenaire" loading="lazy" width="1024" height="1024">
+          <img src="img/partenaire1.png" alt="Partenaire 1" class="logo-partenaire" loading="lazy" width="1024" height="1024">
+          <img src="img/partenaire2.png" alt="Partenaire 2" class="logo-partenaire" loading="lazy" width="1024" height="1024">
         </div>
       </div>
     </div>
@@ -263,7 +263,7 @@
       <iframe
         src="newsletter.html"
         title="Formulaire d'inscription à la newsletter"
-        style="width:100%; height: 430px; border:0; display:block;">
+        style="width:100%; height: 430px; border:0; display:block;" loading="lazy">
       </iframe>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@ footer .footer-links a {
           </div>
         </div>
         <div class="tile hover-rise reveal">
-          <img src="https://images.unsplash.com/photo-1512436991641-6745cdb1723f?q=80&w=1600&auto=format&fit=crop" alt="Objets seconde main, sélection soignée">
+          <img src="https://images.unsplash.com/photo-1512436991641-6745cdb1723f?q=80&w=1600&auto=format&fit=crop" alt="Objets seconde main, sélection soignée" loading="lazy" width="1600" height="1067">
         </div>
       </div>
     </section>
@@ -261,7 +261,7 @@ footer .footer-links a {
           </div>
         </div>
         <div class="tile hover-rise reveal">
-          <img src="https://images.unsplash.com/photo-1523359346063-d879354c0ea5?q=80&w=1600&auto=format&fit=crop" alt="Transparence et confiance">
+          <img src="https://images.unsplash.com/photo-1523359346063-d879354c0ea5?q=80&w=1600&auto=format&fit=crop" alt="Transparence et confiance" loading="lazy" width="1600" height="1067">
         </div>
       </div>
     </section>
@@ -373,7 +373,7 @@ footer .footer-links a {
       <iframe
         src="newsletter.html"
         title="Formulaire d'inscription à la newsletter"
-        style="width:100%; height: 430px; border:0; display:block;">
+        style="width:100%; height: 430px; border:0; display:block;" loading="lazy">
       </iframe>
     </div>
   </div>

--- a/media.html
+++ b/media.html
@@ -126,7 +126,7 @@
 <nav class="navbar navbar-expand-lg bg-white fixed-top shadow-sm">
   <div class="container">
     <a class="navbar-brand d-flex align-items-center" href="accueil.html">
-      <img src="img/logo-yume-solidarite.png" alt="Logo YUME" class="me-2 rounded-circle" width="40">
+      <img src="img/logo-yume-solidarite.png" alt="Logo YUME" class="me-2 rounded-circle" width="40" height="38">
       <div>
         <strong>YUME</strong><br>
         <small>Objets vendus<br> Athlètes soutenus</small>
@@ -201,7 +201,7 @@
   <h2 class="text-center mb-4">Épisode en vedette</h2>
   <div class="row align-items-center">
     <div class="col-md-6">
-      <img src="img/episode5.png" alt="Épisode 5 - Delphine - Alliance Locale" class="img-fluid rounded">
+      <img src="img/episode5.png" alt="Épisode 5 - Delphine - Alliance Locale" class="img-fluid rounded" loading="lazy" width="3000" height="3000">
       <audio controls preload="none" class="w-100 mt-3">
         <source src="audio/Episode 5_Delphine_Alliance locale_YUME.mp3" type="audio/mpeg">
         Ton navigateur ne supporte pas l'audio HTML5.
@@ -226,7 +226,7 @@
   <h2 class="text-center mb-4">Épisode 4 - Véronique (Life Cover)</h2>
   <div class="row align-items-center">
     <div class="col-md-6">
-      <img src="img/episode4.png" alt="Épisode 4 - Véronique - Life Cover" class="img-fluid rounded">
+      <img src="img/episode4.png" alt="Épisode 4 - Véronique - Life Cover" class="img-fluid rounded" loading="lazy" width="3000" height="3000">
       <audio controls preload="none" class="w-100 mt-3">
         <source src="audio/Episode 4_Véronique_Life Cover_YUME.mp3" type="audio/mpeg">
         Ton navigateur ne supporte pas l'audio HTML5.
@@ -249,7 +249,7 @@
   <h2 class="text-center mb-4">Épisode 3- Ella Bassler</h2>
   <div class="row align-items-center">
     <div class="col-md-6">
-      <img src="img/episode3.png" alt="Episode 3" class="img-fluid rounded">
+      <img src="img/episode3.png" alt="Episode 3" class="img-fluid rounded" loading="lazy" width="3000" height="3000">
       <audio controls preload="none" class="w-100 mt-3">
         <source src="audio/Episode 3_Ella Bassler_Incroyable Territoire_YUME.mp3" type="audio/mpeg">
         Ton navigateur ne supporte pas l'audio HTML5.
@@ -274,7 +274,7 @@
   <h2 class="text-center mb-4">Épisode 2 - Ermanno Di Miceli</h2>
   <div class="row align-items-center">
     <div class="col-md-6">
-      <img src="img/episode2.png" alt="Episode 2" class="img-fluid rounded">
+      <img src="img/episode2.png" alt="Episode 2" class="img-fluid rounded" loading="lazy" width="3000" height="3000">
       <audio controls preload="none" class="w-100 mt-3">
         <source src="audio/Episode 2_Ermanno Di Miceli_Ton rêve Ton combat_YUME.mp3" type="audio/mpeg">
         Ton navigateur ne supporte pas l'audio HTML5.
@@ -307,7 +307,7 @@
   <h2 class="text-center mb-4">Épisode 1 – Yannick Matejicek</h2>
   <div class="row align-items-center">
     <div class="col-md-6">
-      <img src="img/episode1.png" alt="Episode" class="img-fluid rounded">
+      <img src="img/episode1.png" alt="Episode" class="img-fluid rounded" loading="lazy" width="3000" height="3000">
       <audio controls preload="none" class="w-100 mt-3">
         <source src="audio/Episode 1_Yannick Matejicek_Ton rêve Ton combat_YUME.mp3" type="audio/mpeg">
         Ton navigateur ne supporte pas l'audio HTML5.
@@ -334,7 +334,7 @@
 <section id="newsletter" class="bg-light py-5">
   <div class="container text-center">
     <h2 class="text-center mb-4">Inscris-toi à notre newsletter</h2>
-    <iframe src="newsletter.html" style="width: 100%; height: 320px; border: none;" title="Formulaire d'inscription à la newsletter" class="rounded"></iframe>
+    <iframe src="newsletter.html" style="width: 100%; height: 320px; border: none;" title="Formulaire d'inscription à la newsletter" class="rounded" loading="lazy"></iframe>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- add `loading="lazy"` to below-the-fold images and iframes
- define width and height on all images to prevent layout shift
- set logo dimensions for consistent navbar layout

## Testing
- `python3 -m http.server` *(fails: cannot access browser to verify lazy loading)*

------
https://chatgpt.com/codex/tasks/task_e_689ef81ae6bc832ba9611021dcb0878b